### PR TITLE
Entry point configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "youtubemusic-api",
   "version": "1.0.0",
   "description": "YouTube Music API Örneği",
-  "main": "index.js",
+  "main": "script.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node public/script.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
@CemoAkcadogan 
I fixed the configuration in the package.json file to make the application run from the script.js file inside the public folder instead of index.js, and now the 'npm start' command is not throwing an error anymore.